### PR TITLE
Fix typo in matrix description in TD_2.tex

### DIFF
--- a/TD/TD_2.tex
+++ b/TD/TD_2.tex
@@ -213,7 +213,7 @@
 			}
 			\item Calculer $(X^T X)^{-1}$.
 			\cor{
-			$(X^T X)^{-1}$ est une matrice diagonale par blocs, on peut donc
+			$(X^T X)$ est une matrice diagonale par blocs, on peut donc
 			l'inverser en prenant l'inverse du premier bloc $(30)^{-1} = 1/30$,
 			et du second
 			\[


### PR DESCRIPTION
Bonjour Monsieur,
TD2, Exo3, question 4.b (Version cor)
C'est XtX qui est bloc-diagonale comme argument qui justifie la manière de l'inverser. Il était initialement écrit (XtX)^-1